### PR TITLE
Integrate dark glass design across UI

### DIFF
--- a/DH & LiquId Glass htmls/DH-HQ_v4.4/index.html
+++ b/DH & LiquId Glass htmls/DH-HQ_v4.4/index.html
@@ -40,7 +40,7 @@
             <rect y="60" width="100" height="15"></rect>
         </svg>
     </button>
-    <div id="dropdown-menu" class="dropdown-menu hidden">
+    <div id="dropdown-menu" class="dropdown-menu glass-panel hidden">
         <a href="index.html">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
@@ -60,7 +60,7 @@
 </header>
 </div>
 <main class="container mx-auto" id="content">
-<div id="welcome-screen">
+<div id="welcome-screen" class="glass-panel">
 <picture class="welcome-logo">
   <img 
     alt="App logo" 
@@ -89,7 +89,7 @@
 
 <section 
   aria-label="Install as a web app" 
-  class="panel install-panel" 
+  class="panel glass-panel install-panel"
   id="install-webapp"
 >
   <h3 class="panel-title">Set up as a Web App</h3>
@@ -99,7 +99,7 @@
 
     <div class="install-columns">
 
-      <div class="install-card">
+      <div class="install-card glass-panel">
         <h4>iPhone (Safari)</h4>
         <ol>
           <li>Open this site in Safari.</li>
@@ -111,7 +111,7 @@
         </p>
       </div>
 
-      <div class="install-card">
+      <div class="install-card glass-panel">
         <h4>iPad (Safari)</h4>
         <ol>
           <li>Open this site in Safari.</li>
@@ -120,7 +120,7 @@
         </ol>
       </div>
 
-      <div class="install-card">
+      <div class="install-card glass-panel">
         <h4>Android (Chrome)</h4>
         <ol>
           <li>Open this site in Chrome.</li>
@@ -129,7 +129,7 @@
         </ol>
       </div>
 
-      <div class="install-card">
+      <div class="install-card glass-panel">
         <h4>Mac (Safari)</h4>
         <ol>
           <li>Open this site in Safari.</li>
@@ -159,7 +159,7 @@
 
 
 <!-- External footnote (below card) -->
-</div><section aria-label="Player Card Legend" class="hidden legend-section panel" id="legend-section"><h3 class="panel-title">Player Card Legend</h3><div aria-label="Roster Player Card Key" class="player-row legend-card" id="rosterPlayerCardKey" role="region">
+</div><section aria-label="Player Card Legend" class="hidden legend-section panel glass-panel" id="legend-section"><h3 class="panel-title">Player Card Legend</h3><div aria-label="Roster Player Card Key" class="player-row legend-card" id="rosterPlayerCardKey" role="region">
 <!-- Top row: Position tag + Player  -->
 <div class="player-main-line legend-main">
 <span class="player-tag legend-pos">POSITION</span>

--- a/DH & LiquId Glass htmls/DH-HQ_v4.4/ownership/ownership.html
+++ b/DH & LiquId Glass htmls/DH-HQ_v4.4/ownership/ownership.html
@@ -36,7 +36,7 @@
             <rect y="60" width="100" height="15"></rect>
         </svg>
     </button>
-    <div id="dropdown-menu" class="dropdown-menu hidden">
+    <div id="dropdown-menu" class="dropdown-menu glass-panel hidden">
         <a href="../">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>

--- a/DH & LiquId Glass htmls/DH-HQ_v4.4/rosters/rosters.html
+++ b/DH & LiquId Glass htmls/DH-HQ_v4.4/rosters/rosters.html
@@ -38,7 +38,7 @@
             <rect y="60" width="100" height="15"></rect>
         </svg>
     </button>
-    <div id="dropdown-menu" class="dropdown-menu hidden">
+    <div id="dropdown-menu" class="dropdown-menu glass-panel hidden">
         <a href="../">Home</a>
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
@@ -87,7 +87,7 @@
 </header>
 </div>
 <main class="container mx-auto" id="content">
-<section aria-label="Player Card Legend" class="hidden legend-section panel" id="legend-section"><h3 class="panel-title">Player Card Legend</h3><div aria-label="Roster Player Card Key" class="player-row legend-card" id="rosterPlayerCardKey" role="region">
+<section aria-label="Player Card Legend" class="hidden legend-section panel glass-panel" id="legend-section"><h3 class="panel-title">Player Card Legend</h3><div aria-label="Roster Player Card Key" class="player-row legend-card" id="rosterPlayerCardKey" role="region">
 <!-- Top row: Position tag + Player  -->
 <div class="player-main-line legend-main">
 <span class="player-tag legend-pos">POSITION</span>
@@ -109,7 +109,7 @@
 </div><div class="legend-footnote" id="rosterCardFootnote">KTC VALUE AND ADP ARE SPECIFIC TO LEAGUE SCORING / FORMAT.</div></section>
 <div class="hidden" id="loading">Loading...</div>
 <div class="hidden" id="rosterView">
-<div id="rosterContainer">
+<div id="rosterContainer" class="glass-panel">
 <div id="rosterGrid"></div>
 </div>
 </div>

--- a/DH & LiquId Glass htmls/DH-HQ_v4.4/styles/styles.css
+++ b/DH & LiquId Glass htmls/DH-HQ_v4.4/styles/styles.css
@@ -197,16 +197,27 @@
 
         /* --- UTILITY CLASSES --- */
         .glass-panel {
-       background-color: rgba(13, 14, 35, 0.21);
-       background-image: linear-gradient(rgba(255,255,255, 0.03), rgba(255,255,255, 0.03));
-        -webkit-backdrop-filter: blur(6px) saturate(120%) brightness(120%);
-        backdrop-filter: blur(6px) saturate(120%) brightness(120%);
-        box-shadow: inset 0 0 0 0px rgba(255,255,255, 0.05), inset 0 0 0 3px rgba(200,200,200, 0.025), 0 10px 26px rgba(0,0,0, var(--outerA, .22));
-        
-        /* Frame */
-        border: 1px solid rgba(128, 138, 189, 0.2);
-        border-radius: 10px;
-        box-shadow: rgba(255, 255, 255, 0.05) 0px 0px 0px 0px inset, rgba(200, 200, 200, 0.025) 0px 0px 0px 3px inset, rgba(0, 0, 0, 0.22) 0px 10px 26px 0px;
+            position: relative;
+            overflow: hidden;
+            background-color: rgba(13, 14, 35, 0.25);
+            background-image: linear-gradient(rgba(255,255,255,0.05), rgba(255,255,255,0.02));
+            -webkit-backdrop-filter: blur(8px) saturate(120%) brightness(120%);
+            backdrop-filter: blur(8px) saturate(120%) brightness(120%);
+            border: 1px solid rgba(128, 138, 189, 0.2);
+            border-radius: 10px;
+            box-shadow: 0 10px 26px rgba(0,0,0,0.22), inset 0 1px 1px rgba(255,255,255,0.05);
+        }
+
+        .glass-panel::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: inherit;
+            background: rgba(255,255,255,0.02);
+            backdrop-filter: blur(1px);
+            box-shadow: inset -10px -8px 0px -11px rgba(255,255,255,0.1),
+                        inset 0 -9px 0px -8px rgba(255,255,255,0.05);
+            pointer-events: none;
         }
         /* --- HEADER & CONTROLS (3-Row Redesign) --- */
         .app-header {
@@ -534,9 +545,10 @@
   }
 }
         /* --- ROSTER VIEW --- */
-        #rosterContainer { 
-            width: 100%; 
-            overflow-x: auto; 
+        #rosterContainer {
+            width: 100%;
+            overflow-x: auto;
+            overflow-y: visible;
             padding: 1px;
         }
         #rosterGrid { 
@@ -665,6 +677,8 @@
 
     /* --- Player & Pick Card Styles --- */
         .player-row, .pick-row {
+            position: relative;
+            overflow: hidden;
             background: var(--color-panel-bg);
             border: 1px solid var(--color-panel-border);
             border-radius: var(--card-border-radius);
@@ -674,9 +688,18 @@
             flex-direction: column;
             gap: 0.1rem;
             transition: all 0.2s ease;
-            backdrop-filter: blur(1px);
-            -webkit-backdrop-filter: blur(1px);
-            box-shadow: 0 0 20px rgba(0,0,0,0.1);
+            -webkit-backdrop-filter: blur(6px) saturate(110%);
+            backdrop-filter: blur(6px) saturate(110%);
+            box-shadow: 0 8px 32px rgba(0,0,0,0.3), inset 0 1px 1px rgba(255,255,255,0.05);
+        }
+
+        .player-row::after, .pick-row::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: inherit;
+            background: rgba(255,255,255,0.02);
+            pointer-events: none;
         }
         .is-trade-mode .player-row, .is-trade-mode .pick-row { 
             cursor: pointer; 
@@ -1746,6 +1769,10 @@ main#content { align-items: stretch !important; }
   }
 }
 
+.install-card {
+  padding: 0.75rem;
+}
+
 .install-card h4 {
   margin: 0 0 0.25rem 0;
   font-size: 0.9rem;
@@ -2022,6 +2049,10 @@ font-weight: 500 !important;
     min-width: 150px;
 }
 
+.dropdown-menu.glass-panel {
+    background-color: transparent;
+}
+
 .dropdown-menu a {
     color: var(--color-text-secondary);
     text-decoration: none;
@@ -2128,12 +2159,7 @@ font-weight: 500 !important;
 
 
 #legend-section {
-            background: var(--color-panel-bg);
-            border: 1px solid var(--color-panel-border);
             border-radius: var(--panel-border-radius);
-            backdrop-filter: blur(3px);
-            -webkit-backdrop-filter: blur(3px);
-            box-shadow: 0 0 20px rgba(0,0,0,0.3);
 }
 
 /* Inline SVG for Trade Preview swap icon */


### PR DESCRIPTION
## Summary
- Introduced reusable dark-mode glass panel styling with layered blur and highlights.
- Applied glass treatment to home components: dropdown menu, welcome screen, install cards, and legend panel.
- Styled roster view with glass navigation, legend, and scrolling container; player cards now render with subtle glass overlay.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68baf329de00832e99b1d9aedc7b5d5c