### PR TITLE
Limit roster player last names to 9 characters

### DIFF
--- a/DH & LiquId Glass htmls/DH-HQ_v4.4/scripts/app.js
+++ b/DH & LiquId Glass htmls/DH-HQ_v4.4/scripts/app.js
@@ -633,9 +633,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             if (!player) return { id: playerId, name: 'Unknown Player', pos: '?', age: '?', team: '?', adp: null, ktc: null, slot, posRank: null };
             const valueData = state.isSuperflex ? state.sflxData[playerId] : state.oneQbData[playerId];
             let lastName = player.last_name || '';
-            if (lastName.includes('-')) lastName = lastName.split('-')[0];
+            if (lastName.length > 9) lastName = lastName.slice(0, 9); // limit last name to 9 chars
             let displayName = `${player.first_name.charAt(0)}. ${lastName}`;
-            if (displayName.length > 15) displayName = displayName.substring(0, 14) + '…';
 
             // Prioritize age from the sheet and format it to one decimal place
             const ageFromSheet = valueData?.age;


### PR DESCRIPTION
## Summary
- Keep hyphenated last names intact and drop previous hyphen truncation rule
- Display roster player names as "F. Lastname" with last names cut off after 9 characters (12 total chars with initial)

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb15ab8e14832e82e12be2694fb5c1